### PR TITLE
Add resursive boolean parameter

### DIFF
--- a/unpack-build-maven-plugin-itests/src/test/resources/integrationtests-project/pom.xml
+++ b/unpack-build-maven-plugin-itests/src/test/resources/integrationtests-project/pom.xml
@@ -25,7 +25,7 @@
         <version>${scm.plugin.version}</version>
         <executions>
           <execution>
-            <id>checkout-drools</id>
+            <id>checkout-repository</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>checkout</goal>

--- a/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/UnpackBuildMojo.java
+++ b/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/UnpackBuildMojo.java
@@ -67,6 +67,9 @@ public class UnpackBuildMojo extends AbstractMojo {
     @Parameter(property = "unpackbuild.rootdirectory", required = true)
     private File rootDirectory;
 
+    @Parameter(property = "unpackbuild.recursive", defaultValue = "false")
+    private boolean recursive;
+
     @Parameter(defaultValue = "${project.version}", property = "unpackbuild.version")
     private String version;
 
@@ -104,7 +107,7 @@ public class UnpackBuildMojo extends AbstractMojo {
             }
 
             final File[] submodules = moduleDirectory.listFiles((FileFilter) DirectoryFileFilter.DIRECTORY);
-            if (submodules != null) {
+            if (recursive && submodules != null) {
                 for (final File submodule : submodules) {
                     downloadAndUnpackArtifact(submodule);
                 }


### PR DESCRIPTION
Resolves #2 .

Adds `recursive` parameter linked to property `unpackbuild.recursive` which decides if sub modules are considered or not.