### PR TITLE
set default for rootDirectory

### DIFF
--- a/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/UnpackBuildMojo.java
+++ b/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/UnpackBuildMojo.java
@@ -64,7 +64,7 @@ public class UnpackBuildMojo extends AbstractMojo {
 
     // Real parameters from here
 
-    @Parameter(property = "unpackbuild.rootdirectory", required = true)
+    @Parameter(property = "unpackbuild.rootdirectory", defaultValue = "${project.basedir}")
     private File rootDirectory;
 
     @Parameter(defaultValue = "${project.version}", property = "unpackbuild.version")


### PR DESCRIPTION
Resolves #1 .

Adding this default value enables users to invoke the plugin easily from cli (as a standalone mojo execution), or invoker (where rootDirectory matches the pom.xml being processed).