### PR TITLE
set project.basedir as default and test by invoker

### DIFF
--- a/unpack-build-maven-plugin-itests/src/test/java/org/kie/unpackbuildplugin/integrationtests/UnpackBuildIT.java
+++ b/unpack-build-maven-plugin-itests/src/test/java/org/kie/unpackbuildplugin/integrationtests/UnpackBuildIT.java
@@ -16,10 +16,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UnpackBuildIT {
 
     private static final String IT_PROJECT_FOLDER = "/integrationtests-project";
+    private static final String IT_PROJECT_FOLDER_INVOKER = "/integrationtests-project-invoker";
 
     @Test
-    public void testBuildProject() throws IOException, VerificationException {
-        final File testDir = ResourceExtractor.simpleExtractResources(getClass(), IT_PROJECT_FOLDER);
+    public void testBuildProjectWithPluginConfig() throws IOException, VerificationException {
+        testBuildProject(IT_PROJECT_FOLDER);
+    }
+
+    @Test
+    public void testBuildProjectUsingInvoker() throws IOException, VerificationException {
+
+        testBuildProject(IT_PROJECT_FOLDER_INVOKER);
+    }
+
+    private void testBuildProject(String projectFolder) throws IOException, VerificationException {
+        final File testDir = ResourceExtractor.simpleExtractResources(getClass(), projectFolder);
         final Verifier verifier = new Verifier(testDir.getAbsolutePath());
         try {
             verifier.executeGoal("clean");

--- a/unpack-build-maven-plugin-itests/src/test/resources/integrationtests-project-invoker/pom.xml
+++ b/unpack-build-maven-plugin-itests/src/test/resources/integrationtests-project-invoker/pom.xml
@@ -12,7 +12,6 @@
     <git.repository.revision>integration-test-1</git.repository.revision>
     <git.revision.type>tag</git.revision.type>
     <repository.directory>./checkout-temp/</repository.directory>
-
     <scm.plugin.version>1.11.1</scm.plugin.version>
     <unpack.build.version>1.0-SNAPSHOT</unpack.build.version>
   </properties>
@@ -41,24 +40,30 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.kie</groupId>
-        <artifactId>unpack-build-maven-plugin</artifactId>
-        <version>${unpack.build.version}</version>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>download-product-jars</id>
             <phase>generate-sources</phase>
             <goals>
-              <goal>unpack-build</goal>
+              <goal>run</goal>
             </goals>
             <configuration>
-              <version>${download.build.version}</version>
-              <outputDirectoryPath>target/classes</outputDirectoryPath>
-              <rootDirectory>${repository.directory}</rootDirectory>
-              <excludeDirectories>
-                <excludeDirectory>^.*-itests</excludeDirectory>
-              </excludeDirectories>
-              <recursive>true</recursive>
+              <goals>
+                <goal>clean</goal>
+                <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
+              </goals>
+              <projectsDirectory>${repository.directory}</projectsDirectory>
+              <pomIncludes>
+                <pomInclude>pom.xml</pomInclude>
+              </pomIncludes>
+              <properties>
+                <unpackbuild.version>${download.build.version}</unpackbuild.version>
+                <unpackbuild.recursive>true</unpackbuild.recursive>
+                <unpackbuild.exclusions>^.*-itests</unpackbuild.exclusions>
+              </properties>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
This attempts at solving #1 

Scope is minimal:

- getting closer to internal maven model by using MavenProject instead of Files as method arguments.
- maven reactor is still not honored when using recursive=true. But when recursive=false it allows to use either from CLI or using invoker as `mvn clean org.kie:unpack-build-maven-plugin:1.0-SNAPSHOT:unpack-build -Dproductized -Dunpackbuild.version=1.2.3.Final` which then honors the reactor (obviously).
- quick win