### PR TITLE
Add override-dependencies goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <maven.version>3.5.4</maven.version>
+    <maven.version>3.8.6</maven.version>
     <plexus.archiver.version>3.7.0</plexus.archiver.version>
     <artifact.transfer.version>0.10.0</artifact.transfer.version>
     <assertj.version>3.11.1</assertj.version>

--- a/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/OverrideDependenciesMojo.java
+++ b/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/OverrideDependenciesMojo.java
@@ -1,0 +1,151 @@
+package org.kie.unpackbuildplugin;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
+import org.kie.unpackbuildplugin.util.PomManipulationUtils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Allows to override version of dependencies before running unpack-build mojo.
+ * Its input is a directory where patched artifacts are located. It loops over *.pom files, reads the GAV and that particular
+ * version uses as an override.<br />
+ * Then it
+ * <ul>
+ *   <li>Adds explicit dependencyManagement section with overriden artifacts into top-level project in reactor.</li>
+ *   <li>Updates version in a module matching to the patched GAV (matched by groupId and artifactId) - so that the unpack-build goal downloads patched binary.</li>
+ * </ul>
+ */
+@Mojo(name = "override-dependencies", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
+public class OverrideDependenciesMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${session}")
+    private MavenSession mavenSession;
+
+    @Parameter(property = "unpackbuild.overriding.poms.directory", required = true)
+    private File overridingPomsDirectory;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!mavenSession.getCurrentProject().isExecutionRoot()) {
+            return;
+        }
+        addDependencyManagementEntries(mavenSession.getTopLevelProject().getOriginalModel());
+        updateVersionsOfPatchedModules(mavenSession.getAllProjects());
+    }
+
+    void addDependencyManagementEntries(Model topLevelProject) throws MojoExecutionException {
+        getLog().info(String.format("About to write dependencyManagement info into %s", topLevelProject.getPomFile()));
+
+        PomManipulationUtils.manipulatePom(topLevelProject, mavenProject -> {
+            DependencyManagement dependencyManagementToAdd = new DependencyManagement();
+            DependencyManagement dependencyManagementOriginal = mavenProject.getModel().getDependencyManagement();
+            // reuse existing dependencyManagement entry, possibly override version
+            if (dependencyManagementOriginal != null) {
+                for (Dependency d : dependencyManagementOriginal.getDependencies()) {
+                    if (isAmongPatchedArtifacts(d)) {
+                        d.setVersion(getMatchingPatchedArtifact(d).get().getVersion());
+                    }
+                    dependencyManagementToAdd.addDependency(d);
+                }
+            }
+            // filter patched artifacts not initially present in dependencyManagement and add explicitly
+            for (Model m : getListOfPatchedArtifacts()) {
+                if (dependencyManagementToAdd.getDependencies().stream().noneMatch(it -> isSameArtifact(it, m))) {
+                    Dependency d = new Dependency();
+                    d.setArtifactId(m.getArtifactId());
+                    d.setGroupId(StringUtils.isEmpty(m.getGroupId()) ? m.getParent().getGroupId() : m.getGroupId());
+                    d.setVersion(m.getVersion());
+                    dependencyManagementToAdd.addDependency(d);
+                }
+            }
+            mavenProject.getModel().setDependencyManagement(dependencyManagementToAdd);
+        });
+    }
+
+    void updateVersionsOfPatchedModules(List<MavenProject> projects) throws MojoExecutionException {
+        getLog().info("About to update versions of patched modules.");
+        for (MavenProject mavenProject : projects) {
+            Model model = mavenProject.getOriginalModel();
+            if (isAmongPatchedArtifacts(model)) {
+                getLog().info(String.format("Upgrading version of module %s", mavenProject.getFile()));
+                PomManipulationUtils.manipulatePom(model, it -> {
+                    String patchedVersion = getMatchingPatchedArtifact(it.getModel()).get().getVersion();
+                    it.setVersion(patchedVersion);
+                    getLog().info(String.format("Overriding artifact %s:%s version to %s", it.getGroupId(), it.getArtifactId(), it.getVersion()));
+                });
+            }
+        }
+    }
+
+    List<Model> getListOfPatchedArtifacts() {
+        List<Model> artifacts = new ArrayList<>();
+        if (overridingPomsDirectory == null || !overridingPomsDirectory.isDirectory()) {
+            throw new RuntimeException("The provided unzipped patch directory does not exist.");
+        }
+        for (File pomFile : overridingPomsDirectory.listFiles(it -> it.getName().endsWith(".pom"))) {
+            Model model = null;
+            try {
+                model = PomManipulationUtils.loadPomModel(pomFile.toPath());
+            } catch (MojoExecutionException e) {
+                throw new RuntimeException("Cannot load pom modules from the unzipped patch directory.", e);
+            }
+            artifacts.add(model);
+        }
+        return artifacts;
+    }
+
+    boolean isAmongPatchedArtifacts(Model m1) {
+        return
+                getMatchingPatchedArtifact(m1).isPresent();
+    }
+
+    boolean isAmongPatchedArtifacts(Dependency d1) {
+        return
+                getMatchingPatchedArtifact(d1).isPresent();
+    }
+
+    Optional<Model> getMatchingPatchedArtifact(Model m1) {
+        return getListOfPatchedArtifacts().stream().filter(it -> isSameArtifact(it, m1)).findAny();
+    }
+
+    Optional<Model> getMatchingPatchedArtifact(Dependency d1) {
+        return getListOfPatchedArtifacts().stream().filter(it -> isSameArtifact(d1, it)).findAny();
+    }
+
+    private boolean isSameArtifact(Model m1, Model m2) {
+        if (m1 == null || m2 == null) {
+            return false;
+        }
+        // rely on MavenProject for parent handling (groupId, version)
+        MavenProject mp1 = new MavenProject();
+        mp1.setModel(m1);
+        MavenProject mp2 = new MavenProject();
+        mp2.setModel(m2);
+        return Objects.equals(mp1.getGroupId(), mp2.getGroupId()) && Objects.equals(mp1.getArtifactId(), mp2.getArtifactId());
+    }
+
+    private boolean isSameArtifact(Dependency d1, Model m1) {
+        if (d1 == null || m1 == null) {
+            return false;
+        }
+        // rely on MavenProject for parent handling (groupId, version)
+        MavenProject mp1 = new MavenProject();
+        mp1.setModel(m1);
+        return Objects.equals(d1.getGroupId(), mp1.getGroupId()) && Objects.equals(d1.getArtifactId(), mp1.getArtifactId());
+    }
+}

--- a/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/util/PomManipulationUtils.java
+++ b/unpack-build-maven-plugin/src/main/java/org/kie/unpackbuildplugin/util/PomManipulationUtils.java
@@ -1,0 +1,61 @@
+package org.kie.unpackbuildplugin.util;
+
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+
+public class PomManipulationUtils {
+
+    private PomManipulationUtils() {
+        // private constructor to prevent instantiation
+    }
+
+    /**
+     * Get Maven Model from given pomFile.
+     *
+     * @param pomFile path to pom.xml
+     * @return
+     * @throws MojoExecutionException
+     */
+    public static Model loadPomModel(Path pomFile) throws MojoExecutionException {
+        Model model = null;
+        try (
+                FileInputStream fileReader = new FileInputStream(pomFile.toFile());) {
+            MavenXpp3Reader mavenReader = new MavenXpp3Reader();
+            model = mavenReader.read(fileReader);
+            model.setPomFile(pomFile.toFile());
+        } catch (IOException | XmlPullParserException e) {
+            throw new MojoExecutionException("Error while opening generated pom: " + pomFile, e);
+        }
+        return model;
+    }
+
+    /**
+     * Method that accepts maven Model for given pom file and operation to be applied on the MavenProject
+     * instance denoted by the Model instance.
+     *
+     * @param model       Loaded maven pom model to manipulate and save to after changes.
+     * @param manipulator consumer that receives {@linkplain MavenProject} instance.
+     * @throws MojoExecutionException when error during manipulation occurs.
+     */
+    public static void manipulatePom(Model model, Consumer<MavenProject> manipulator) throws MojoExecutionException {
+        try (
+                FileOutputStream fileWriter = new FileOutputStream(model.getPomFile())) {
+            MavenProject project = new MavenProject(model);
+            manipulator.accept(project);
+            MavenXpp3Writer mavenWriter = new MavenXpp3Writer();
+            mavenWriter.write(fileWriter, model);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error while saving manipulated pom: " + model.getPomFile(), e);
+        }
+    }
+}

--- a/unpack-build-maven-plugin/src/test/java/org/kie/unpackbuildplugin/OverrideDependenciesMojoTest.java
+++ b/unpack-build-maven-plugin/src/test/java/org/kie/unpackbuildplugin/OverrideDependenciesMojoTest.java
@@ -1,0 +1,115 @@
+package org.kie.unpackbuildplugin;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.project.MavenProject;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.kie.unpackbuildplugin.util.PomManipulationUtils;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+public class OverrideDependenciesMojoTest {
+    @Rule
+    public MojoRule rule = new MojoRule() {
+        @Override
+        protected void before() throws Throwable {
+        }
+
+        @Override
+        protected void after() {
+        }
+    };
+
+    public OverrideDependenciesMojo getMojo(String pomResourceString) {
+        try {
+            return (OverrideDependenciesMojo) rule.lookupMojo("override-dependencies", new File(getClass().getResource(pomResourceString).toURI()));
+        } catch (Exception e) {
+            Assertions.fail("Failure initializing mojo in tests.", e);
+        }
+        return null;
+    }
+
+    @Test
+    public void testGetListOfPatchedArtifacts() throws MojoExecutionException {
+        OverrideDependenciesMojo mojo = getMojo("/override-dependencies-mojo/project1/pom.xml");
+        Assertions.assertThat(mojo.getListOfPatchedArtifacts()).hasSize(2);
+        Assertions.assertThat(mojo.getListOfPatchedArtifacts()).anyMatch(it -> {
+            MavenProject mp = new MavenProject();
+            mp.setModel(it);
+            return mp.getGroupId().equals("org.acme")
+                    && mp.getArtifactId().equals("module1")
+                    && mp.getVersion().equals("1.0-patched");
+        });
+    }
+
+    @Test
+    public void testIsAmongPatchedArtifacts() {
+        OverrideDependenciesMojo mojo = getMojo("/override-dependencies-mojo/project1/pom.xml");
+        Model m = new Model();
+        m.setGroupId("org.acme");
+        m.setArtifactId("module1");
+        Assertions.assertThat(mojo.isAmongPatchedArtifacts(m)).isEqualTo(true);
+        Dependency d = new Dependency();
+        d.setGroupId("org.acme");
+        d.setArtifactId("module1");
+        Assertions.assertThat(mojo.isAmongPatchedArtifacts(d)).isEqualTo(true);
+        Model m2 = new Model();
+        m2.setGroupId("org.acme");
+        m2.setArtifactId("module2");
+        Assertions.assertThat(mojo.isAmongPatchedArtifacts(m2)).isEqualTo(false);
+        Dependency d2 = new Dependency();
+        d2.setGroupId("org.acme");
+        d2.setArtifactId("module2");
+        Assertions.assertThat(mojo.isAmongPatchedArtifacts(d2)).isEqualTo(false);
+    }
+
+    @Test
+    public void testAddDependencyManagementSection() throws MojoExecutionException {
+        OverrideDependenciesMojo mojo = getMojo("/override-dependencies-mojo/project1/pom.xml");
+        Model topLevelProject = PomManipulationUtils.loadPomModel(Paths.get(getClass().getResource("/override-dependencies-mojo/project1/pom.xml").getFile()));
+        mojo.addDependencyManagementEntries(topLevelProject);
+        DependencyManagement updatedDependencyManagement = topLevelProject.getDependencyManagement();
+        Assertions.assertThat(updatedDependencyManagement).isNotNull();
+        Assertions.assertThat(updatedDependencyManagement.getDependencies()).hasSize(3);
+        Assertions.assertThat(updatedDependencyManagement.getDependencies()).anyMatch(it ->
+                it.getGroupId().equals("org.acme")
+                        && it.getArtifactId().equals("module1")
+                        && it.getVersion().equals("1.0-patched"));
+    }
+
+    @Test
+    public void testUpdateVersionsOfPatchedModules() throws MojoExecutionException {
+        OverrideDependenciesMojo mojo = getMojo("/override-dependencies-mojo/project1/pom.xml");
+
+        Model parentModel = PomManipulationUtils.loadPomModel(Paths.get(getClass().getResource("/override-dependencies-mojo/project1/pom.xml").getFile()));
+        MavenProject parentProject = new MavenProject();
+        parentProject.setModel(parentModel);
+        parentProject.setOriginalModel(parentModel);
+
+        Model module1Model = PomManipulationUtils.loadPomModel(Paths.get(getClass().getResource("/override-dependencies-mojo/project1/module1/pom.xml").getFile()));
+        MavenProject module1Project = new MavenProject();
+        module1Project.setModel(module1Model);
+        module1Project.setOriginalModel(module1Model);
+
+        Model module2model = PomManipulationUtils.loadPomModel(Paths.get(getClass().getResource("/override-dependencies-mojo/project1/module2/pom.xml").getFile()));
+        MavenProject module2Project = new MavenProject();
+        module2Project.setModel(module2model);
+        module2Project.setOriginalModel(module2model);
+
+        mojo.updateVersionsOfPatchedModules(Arrays.asList(new MavenProject[]{parentProject, module1Project, module2Project}));
+
+        Assertions.assertThat(parentModel.getVersion()).isEqualTo("1.0");
+        Assertions.assertThat(parentProject.getVersion()).isEqualTo("1.0");
+        Assertions.assertThat(module1Model.getVersion()).isEqualTo("1.0-patched");
+        Assertions.assertThat(module1Project.getVersion()).isEqualTo("1.0-patched");
+        Assertions.assertThat(module2model.getVersion()).isNull();
+        Assertions.assertThat(module2Project.getVersion()).isEqualTo("1.0");
+    }
+}

--- a/unpack-build-maven-plugin/src/test/java/org/kie/unpackbuildplugin/util/PomManipulationUtilsTest.java
+++ b/unpack-build-maven-plugin/src/test/java/org/kie/unpackbuildplugin/util/PomManipulationUtilsTest.java
@@ -1,0 +1,50 @@
+package org.kie.unpackbuildplugin.util;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class PomManipulationUtilsTest {
+
+    @Rule
+    public ExpectedException exceptionGrabber = ExpectedException.none();
+
+    @Test
+    public void loadSimplePomModel() throws MojoExecutionException {
+        Model pomModel = PomManipulationUtils.loadPomModel(Paths.get(getClass().getResource("/pom-manipulation-utils/simple-pom.xml").getFile()).toAbsolutePath());
+        Assertions.assertThat(pomModel.getGroupId()).isEqualTo("org.acme");
+        Assertions.assertThat(pomModel.getArtifactId()).isEqualTo("simple-pom");
+    }
+
+    @Test
+    public void loadInvalidPomModel() throws MojoExecutionException {
+        exceptionGrabber.expect(MojoExecutionException.class);
+        exceptionGrabber.expectMessage("Error while opening generated pom: ");
+        PomManipulationUtils.loadPomModel(Paths.get(getClass().getResource("/pom-manipulation-utils/invalid-pom.xml").getFile()).toAbsolutePath());
+    }
+
+    @Test
+    public void manipulateSimplePomModel() throws MojoExecutionException, IOException {
+        Path pomFile = Paths.get(getClass().getResource("/pom-manipulation-utils/simple-pom.xml").getFile()).toAbsolutePath();
+        Model pomModel = PomManipulationUtils.loadPomModel(pomFile);
+        Assertions.assertThat(pomModel.getGroupId()).isEqualTo("org.acme");
+        Assertions.assertThat(pomModel.getArtifactId()).isEqualTo("simple-pom");
+        Assertions.assertThat(pomModel.getProperties()).hasSize(0);
+        File tmpCpy = File.createTempFile("pom-manipulation-test", null);
+        FileUtils.copyFile(pomFile.toFile(), tmpCpy);
+        PomManipulationUtils.manipulatePom(PomManipulationUtils.loadPomModel(tmpCpy.toPath()), it -> it.getProperties().put("test.prop", "value"));
+        Model pomModelAfterSave = PomManipulationUtils.loadPomModel(tmpCpy.toPath());
+        Assertions.assertThat(pomModelAfterSave.getProperties()).hasSize(1);
+        Assertions.assertThat(pomModelAfterSave.getProperties()).hasEntrySatisfying("test.prop", it -> Assertions.assertThat(it).isEqualTo("value"));
+    }
+
+}

--- a/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/patch-unzipped/module1.pom
+++ b/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/patch-unzipped/module1.pom
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>parent-project</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>module1</artifactId>
+  <version>1.0-patched</version>
+  <packaging>jar</packaging>
+  <name>Test OverrideDependenciesMojo :: Module1</name>
+</project>

--- a/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/patch-unzipped/moduleX.pom
+++ b/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/patch-unzipped/moduleX.pom
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.acme2</groupId>
+  <artifactId>moduleX</artifactId>
+  <version>0.9-X</version>
+  <packaging>jar</packaging>
+  <name>Test OverrideDependenciesMojo :: ModuleX - this one should not affect execution.</name>
+</project>

--- a/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/project1/module1/pom.xml
+++ b/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/project1/module1/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>parent-project</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>module1</artifactId>
+  <packaging>jar</packaging>
+  <name>Test OverrideDependenciesMojo :: Module1</name>
+</project>

--- a/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/project1/module2/pom.xml
+++ b/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/project1/module2/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.acme</groupId>
+    <artifactId>parent-project</artifactId>
+    <version>1.0</version>
+  </parent>
+  <artifactId>module2</artifactId>
+  <packaging>jar</packaging>
+  <name>Test OverrideDependenciesMojo :: Module2</name>
+</project>

--- a/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/project1/pom.xml
+++ b/unpack-build-maven-plugin/src/test/resources/override-dependencies-mojo/project1/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.acme</groupId>
+  <artifactId>parent-project</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+  <name>Test OverrideDependenciesMojo :: parent</name>
+  <modules>
+    <module>module1</module>
+    <module>module2</module>
+  </modules>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.acme</groupId>
+        <artifactId>some-artifact</artifactId>
+        <version>0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.acme2</groupId>
+        <artifactId>moduleX</artifactId>
+        <version>0.9</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>unpack-build-maven-plugin</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <configuration>
+          <overridingPomsDirectory>${basedir}/target/test-classes/override-dependencies-mojo/patch-unzipped</overridingPomsDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>override-dependencies</goal>
+            </goals>
+            <phase>generate-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/unpack-build-maven-plugin/src/test/resources/pom-manipulation-utils/invalid-pom.xml
+++ b/unpack-build-maven-plugin/src/test/resources/pom-manipulation-utils/invalid-pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupID>org.acme</groupID>
+  <artifactId>simple-pom</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test PomManipulationUtils</name>
+</project>

--- a/unpack-build-maven-plugin/src/test/resources/pom-manipulation-utils/simple-pom.xml
+++ b/unpack-build-maven-plugin/src/test/resources/pom-manipulation-utils/simple-pom.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.acme</groupId>
+  <artifactId>simple-pom</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+  <name>Test PomManipulationUtils</name>
+</project>


### PR DESCRIPTION
Introducing `override-dependencies` goal that has one configuration property - directory containing the overriding maven artifacts (pom files are the only ones considered by the goal itself).

The idea is to run first this `override-dependencies` goal and `unpack-build` right after.

Tests
* Are located in the implementing module itself. To make those running, an upgrade of `maven.version` was needed - did not identify the root cause, but seems like a inconsistency in transitive dependencies.
* No integration tests were added into *-itests module, please let me know if an integration test is a must have, based on that test coverage is provided in the implementing ~plugin~ module itself.